### PR TITLE
feat(trace): 1ターンの全LLM呼び出しをTrace Graphにノード化 (issue #51)

### DIFF
--- a/butly_core/chat/service.py
+++ b/butly_core/chat/service.py
@@ -289,7 +289,17 @@ def _build_and_save_trace(
     応答に影響させない。
     """
     try:
+        from butly_core.settings import get_settings
+
+        trace_cfg = get_settings().system.trace or {}
+        if not trace_cfg.get("enabled", True):
+            return
+    except Exception as e:
+        print(f"[ChatService] trace 設定読み込みエラー、既定 (enabled) で継続: {e}")
+
+    try:
         from butly_core.trace import build_chat_trace
+        from butly_core.trace.collector import get_collected
 
         session_dict = session_state.to_dict() if session_state else {}
         trace = build_chat_trace(
@@ -310,6 +320,7 @@ def _build_and_save_trace(
             timing=debug_info.get("timing"),
             token_estimate=debug_info.get("token_estimate"),
             generation_error=generation_error,
+            llm_calls=get_collected(),
             turn_id=session_dict.get("turn_count"),
             source=getattr(request, "source", "web"),
             created_at=datetime.datetime.now().isoformat(timespec="seconds"),
@@ -676,6 +687,35 @@ class ChatService:
         -------
         ChatResponse
         """
+        from butly_core.trace.collector import reset_collection, start_collection
+
+        # Trace Graph (issue #51): ターン全体の LLM 呼び出しを収集する。
+        # token reset を finally に置くことで、例外経路でも収集が残留しない。
+        _trace_token = start_collection()
+        try:
+            return await ChatService._execute_impl(
+                request=request,
+                get_instance_components=get_instance_components,
+                instance_manager=instance_manager,
+                instances_dir=instances_dir,
+                gatekeeper=gatekeeper,
+                mem_block_builder=mem_block_builder,
+                ws_manager=ws_manager,
+            )
+        finally:
+            reset_collection(_trace_token)
+
+    @staticmethod
+    async def _execute_impl(
+        request: ChatRequest,
+        get_instance_components,
+        instance_manager,
+        instances_dir: Path,
+        gatekeeper,
+        mem_block_builder,
+        ws_manager=None,
+    ) -> ChatResponse:
+        """execute() の本体 (LLM 呼び出し収集の内側で実行される)。"""
         from butly_core.config import AI_CONFIG
 
         _t_start = time.time()
@@ -733,14 +773,30 @@ class ChatService:
         state_elapsed_ms = {"value": 0}
 
         async def _run_generate():
+            from butly_core.trace.collector import record_llm_call
+
             t0 = time.time()
-            res = await run_in_threadpool(
-                provider.generate,
-                text=full_prompt,
-                attachments=request.attachments if has_attachments else [],
-                context=context,
-            )
-            gen_elapsed_ms["value"] = int((time.time() - t0) * 1000)
+            gen_error = None
+            try:
+                res = await run_in_threadpool(
+                    provider.generate,
+                    text=full_prompt,
+                    attachments=request.attachments if has_attachments else [],
+                    context=context,
+                )
+            except Exception as e:
+                gen_error = str(e)
+                raise
+            finally:
+                gen_elapsed_ms["value"] = int((time.time() - t0) * 1000)
+                record_llm_call(
+                    purpose="chat_generate",
+                    model=model_name,
+                    connection_id=connection_id,
+                    duration_ms=gen_elapsed_ms["value"],
+                    prompt_chars=len(full_prompt),
+                    error=gen_error,
+                )
             return res
 
         async def _run_state_update():
@@ -980,6 +1036,34 @@ class ChatService:
           - {"type": "done", "data": {timing, debug, session_state, sources, ...}}
           - {"type": "error", "message": str, "recoverable": bool}
         """
+        from butly_core.trace.collector import reset_collection, start_collection
+
+        # Trace Graph (issue #51): generator 全体を包む位置で収集を開始し、
+        # yield をまたいでも finally で必ず reset する。
+        _trace_token = start_collection()
+        try:
+            async for event in ChatService._execute_stream_impl(
+                request=request,
+                get_instance_components=get_instance_components,
+                instance_manager=instance_manager,
+                instances_dir=instances_dir,
+                gatekeeper=gatekeeper,
+                mem_block_builder=mem_block_builder,
+            ):
+                yield event
+        finally:
+            reset_collection(_trace_token)
+
+    @staticmethod
+    async def _execute_stream_impl(
+        request: ChatRequest,
+        get_instance_components,
+        instance_manager,
+        instances_dir: Path,
+        gatekeeper,
+        mem_block_builder,
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """execute_stream() の本体 (LLM 呼び出し収集の内側で実行される)。"""
         from butly_core.config import AI_CONFIG
 
         _t_start = time.time()
@@ -1093,6 +1177,18 @@ class ChatService:
 
         _t_gen_end = time.time()
         gen_elapsed_ms = int((_t_gen_end - _t_gen_start) * 1000)
+
+        # Trace Graph 用: main 生成の呼び出し記録 (成功/失敗どちらも)
+        from butly_core.trace.collector import record_llm_call
+
+        record_llm_call(
+            purpose="chat_generate",
+            model=model_name,
+            connection_id=connection_id,
+            duration_ms=gen_elapsed_ms,
+            prompt_chars=len(full_prompt),
+            error=stream_err,
+        )
 
         if stream_err:
             # cancel state_task to free resources

--- a/butly_core/config.py
+++ b/butly_core/config.py
@@ -148,6 +148,13 @@ SYSTEM_CONFIG = {
         # 注入合計文字数の上限（greedy skip）
         "max_chars": 4000,
     },
+    # Trace Graph (issue #51)。enabled は trace.json 保存の ON/OFF、
+    # detail / hidden_nodes は表示フィルタ (保存は常に full)。
+    "trace": {
+        "enabled": True,
+        "detail": "full",
+        "hidden_nodes": [],
+    },
 }
 
 # --- User Config Override ---

--- a/butly_core/core/brain.py
+++ b/butly_core/core/brain.py
@@ -3,10 +3,13 @@ import json
 import re
 import sqlite3
 import math
+import time
 import numpy as np
 from pathlib import Path
 from datetime import datetime
 from dotenv import load_dotenv
+
+from butly_core.trace.collector import record_llm_call
 
 # ★設定ファイルのインポート
 try:
@@ -78,14 +81,31 @@ class ButlyBrain:
             return 0.0
 
     def get_embedding(self, text):
+        # Phase 2: connection + model_name の dict 全体を Provider に渡す。
+        # Provider 側 (OpenAICompatAdapter) は config["model_name"] を最優先で使う。
+        embedding_cfg = AI_CONFIG.get("embedding", {})
+        t0 = time.time()
         try:
-            # Phase 2: connection + model_name の dict 全体を Provider に渡す。
-            # Provider 側 (OpenAICompatAdapter) は config["model_name"] を最優先で使う。
-            embedding_cfg = AI_CONFIG["embedding"]
             provider = self._get_provider(embedding_cfg)
-            return provider.embed(text, config=embedding_cfg)
+            result = provider.embed(text, config=embedding_cfg)
+            record_llm_call(
+                purpose="embedding",
+                model=embedding_cfg.get("model_name", ""),
+                connection_id=embedding_cfg.get("connection", ""),
+                duration_ms=int((time.time() - t0) * 1000),
+                prompt_chars=len(text) if text else 0,
+            )
+            return result
         except Exception as e:
             print(f"[Brain] Embedding Error: {e}")
+            record_llm_call(
+                purpose="embedding",
+                model=embedding_cfg.get("model_name", ""),
+                connection_id=embedding_cfg.get("connection", ""),
+                duration_ms=int((time.time() - t0) * 1000),
+                prompt_chars=len(text) if text else 0,
+                error=str(e),
+            )
             return None
 
     def _merge_config(self, base_conf, override_conf):
@@ -151,7 +171,24 @@ class ButlyBrain:
 
             # Phase 2: chat_conf (connection + model_name) を Provider Factory に渡す
             provider = self._get_provider(chat_conf)
-            text = provider.classify(prompt, chat_conf)
+            t0 = time.time()
+            call_error = None
+            try:
+                text = provider.classify(prompt, chat_conf)
+            except Exception as call_e:
+                call_error = str(call_e)
+                raise
+            finally:
+                # LLM 呼び出し自体の成否だけを記録する (後続の JSON パース失敗は
+                # 呼び出し失敗ではないため、ここで finally 記録する)
+                record_llm_call(
+                    purpose="keyword_extract",
+                    model=chat_conf.get("model_name", ""),
+                    connection_id=chat_conf.get("connection", ""),
+                    duration_ms=int((time.time() - t0) * 1000),
+                    prompt_chars=len(prompt),
+                    error=call_error,
+                )
             text = text.strip() if text else ""
             print(f"[Brain] Raw Keyword Response: {text}")
 

--- a/butly_core/core/gatekeeper/context_classifier.py
+++ b/butly_core/core/gatekeeper/context_classifier.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from butly_core.config import AI_CONFIG, SYSTEM_CONFIG
 from butly_core.prompts import PromptLoader
 from butly_core.core.gatekeeper.memory_probe import asks_for_specific_past_detail
+from butly_core.trace.collector import record_llm_call
 
 VALID_NEED_INTENTS = ("past_fact", "glossary", "relationship")
 
@@ -128,11 +129,26 @@ class ContextClassifier:
                 gk_config if gk_config.get("model_name") else model_name
             )
             raw_text = provider.classify(prompt, gk_config)
+            record_llm_call(
+                purpose="context_classifier",
+                model=model_name,
+                connection_id=gk_config.get("connection", ""),
+                duration_ms=int((time.time() - t0) * 1000),
+                prompt_chars=len(prompt),
+            )
             result = self._parse_response(
                 raw_text, user_input, override_config=override_config
             )
         except Exception as e:
             print(f"[ContextClassifier] API呼び出しエラー: {e}")
+            record_llm_call(
+                purpose="context_classifier",
+                model=model_name,
+                connection_id=gk_config.get("connection", ""),
+                duration_ms=int((time.time() - t0) * 1000),
+                prompt_chars=len(prompt),
+                error=str(e),
+            )
             result = self._default_output(user_input)
 
         t1 = time.time()

--- a/butly_core/core/gatekeeper/state_updater.py
+++ b/butly_core/core/gatekeeper/state_updater.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from butly_core.config import AI_CONFIG, SYSTEM_CONFIG
 from butly_core.prompts import PromptLoader
+from butly_core.trace.collector import record_llm_call
 
 
 class StateUpdater:
@@ -98,9 +99,24 @@ class StateUpdater:
                 gk_config if gk_config.get("model_name") else model_name
             )
             raw_text = provider.classify(prompt, gk_config)
+            record_llm_call(
+                purpose="state_updater",
+                model=model_name,
+                connection_id=gk_config.get("connection", ""),
+                duration_ms=int((time.time() - t0) * 1000),
+                prompt_chars=len(prompt),
+            )
             result = self._parse_response(raw_text)
         except Exception as e:
             print(f"[StateUpdater] API呼び出しエラー: {e}")
+            record_llm_call(
+                purpose="state_updater",
+                model=model_name,
+                connection_id=gk_config.get("connection", ""),
+                duration_ms=int((time.time() - t0) * 1000),
+                prompt_chars=len(prompt),
+                error=str(e),
+            )
             result = self._default_output()
 
         t1 = time.time()

--- a/butly_core/settings/defaults.py
+++ b/butly_core/settings/defaults.py
@@ -129,4 +129,14 @@ SYSTEM_CONFIG = {
         "max_entries": 20,
         "max_chars": 4000,
     },
+    # Trace Graph (issue #51)
+    # enabled: trace.json の保存 ON/OFF。
+    # detail / hidden_nodes: 表示フィルタ (保存は常に full)。
+    #   detail: "full" | "summary" (summary は補助 LLM ノードを非表示)
+    #   hidden_nodes: purpose または node id のリスト (例: ["embedding"])
+    "trace": {
+        "enabled": True,
+        "detail": "full",
+        "hidden_nodes": [],
+    },
 }

--- a/butly_core/settings/system.py
+++ b/butly_core/settings/system.py
@@ -34,3 +34,4 @@ class SystemConfig(BaseModel):
     )
     chat: dict[str, Any] = Field(default_factory=lambda: _section_default("chat"))
     glossary: dict[str, Any] = Field(default_factory=lambda: _section_default("glossary"))
+    trace: dict[str, Any] = Field(default_factory=lambda: _section_default("trace"))

--- a/butly_core/trace/__init__.py
+++ b/butly_core/trace/__init__.py
@@ -7,10 +7,21 @@ Trace Graph: 1 回答の生成フローをノード + エッジのグラフと�
 公開 API:
   - ``build_chat_trace(...)``  : ChatService の実行事実から TraceGraph を構築
   - ``render_mermaid(trace)``  : TraceGraph を Mermaid flowchart 文字列へ変換
+  - ``filter_trace(trace)``    : detail / hidden_nodes による表示フィルタ
+  - collector (``start_collection`` / ``record_llm_call`` 等):
+    ターン中の LLM 呼び出しを ContextVar 経由で収集
   - ``TraceGraph`` / ``TraceNode`` / ``TraceEdge`` : DTO
 """
 
 from butly_core.trace.builder import build_chat_trace
+from butly_core.trace.collector import (
+    get_collected,
+    is_collecting,
+    record_llm_call,
+    reset_collection,
+    start_collection,
+)
+from butly_core.trace.filters import filter_trace
 from butly_core.trace.mermaid import render_mermaid
 from butly_core.trace.types import (
     TRACE_SCHEMA_VERSION,
@@ -23,6 +34,12 @@ from butly_core.trace.types import (
 __all__ = [
     "build_chat_trace",
     "render_mermaid",
+    "filter_trace",
+    "start_collection",
+    "reset_collection",
+    "record_llm_call",
+    "get_collected",
+    "is_collecting",
     "TraceGraph",
     "TraceNode",
     "TraceEdge",

--- a/butly_core/trace/builder.py
+++ b/butly_core/trace/builder.py
@@ -55,6 +55,74 @@ def _web_search_reason(web_search_status: str, count: int) -> str:
     return reasons.get(web_search_status, "対象外")
 
 
+# 補助 LLM ノード (collector 由来) の purpose → 表示ラベル
+_AUX_LABELS: Dict[str, str] = {
+    "context_classifier": "Context Classifier (LLM)",
+    "state_updater": "State Updater (LLM)",
+    "embedding": "Embedding",
+    "keyword_extract": "Keyword Extract (LLM)",
+}
+
+# 補助 LLM ノードをぶら下げる親ノード (メインフロー上の位置)
+_AUX_PARENTS: Dict[str, str] = {
+    "context_classifier": "gatekeeper",
+    "embedding": "memory_probe",
+    "keyword_extract": "memory_probe",
+    "state_updater": "state_update",
+}
+
+
+def _append_aux_llm_nodes(
+    nodes: List[TraceNode],
+    edges: List[TraceEdge],
+    llm_calls: List[Dict[str, Any]],
+) -> None:
+    """collector が収集した補助 LLM 呼び出しをノード化して追加する。
+
+    main 生成 (purpose="chat_generate") は既存の ``llm_call`` ノードが担うため
+    ここでは追加しない (metadata 拡充は呼び出し元で行う)。同一 purpose が複数回
+    ある場合 (embedding 等) は ``llm_embedding`` / ``llm_embedding_2`` と連番にする。
+    """
+    counts: Dict[str, int] = {}
+    for call in llm_calls:
+        purpose = call.get("purpose") or "llm"
+        if purpose == "chat_generate":
+            continue
+        counts[purpose] = counts.get(purpose, 0) + 1
+        idx = counts[purpose]
+        node_id = f"llm_{purpose}" if idx == 1 else f"llm_{purpose}_{idx}"
+
+        error = call.get("error")
+        status: TraceStatus = "error" if error else "active"
+        model = call.get("model") or ""
+        duration = call.get("duration_ms")
+        if error:
+            summary = summarize_text(error)
+        else:
+            summary = model + (f" ({duration}ms)" if duration is not None else "")
+
+        nodes.append(
+            TraceNode(
+                id=node_id,
+                label=_AUX_LABELS.get(purpose, purpose),
+                type="llm",
+                status=status,
+                summary=summary or None,
+                metadata={
+                    "aux": True,
+                    "purpose": purpose,
+                    "model": model,
+                    "connection_id": call.get("connection_id", ""),
+                    "duration_ms": duration,
+                    "prompt_chars": call.get("prompt_chars"),
+                    **({"error": error} if error else {}),
+                },
+            )
+        )
+        parent = _AUX_PARENTS.get(purpose, "llm_call")
+        edges.append(TraceEdge(source=parent, target=node_id, status=status))
+
+
 def build_chat_trace(
     *,
     instance_name: str,
@@ -74,15 +142,26 @@ def build_chat_trace(
     timing: Optional[Dict[str, Any]] = None,
     token_estimate: Optional[Dict[str, Any]] = None,
     generation_error: Optional[str] = None,
+    llm_calls: Optional[List[Dict[str, Any]]] = None,
     turn_id: Optional[int] = None,
     source: str = "web",
     created_at: Optional[str] = None,
 ) -> TraceGraph:
-    """1 ターン分の回答生成フローを TraceGraph として組み立てる。"""
+    """1 ターン分の回答生成フローを TraceGraph として組み立てる。
+
+    ``llm_calls`` は collector が収集した LLM 呼び出し記録。補助 LLM
+    (context_classifier / embedding / keyword_extract / state_updater) は
+    個別ノードとして追加され、main 生成 (chat_generate) は既存 ``llm_call``
+    ノードの metadata を拡充する。
+    """
     gk_result = gk_result or {}
     memory_blocks = memory_blocks or {}
     timing = timing or {}
     token_estimate = token_estimate or {}
+    llm_calls = list(llm_calls or [])
+    chat_gen_rec = next(
+        (c for c in llm_calls if c.get("purpose") == "chat_generate"), None
+    )
 
     nodes: List[TraceNode] = []
     edges: List[TraceEdge] = []
@@ -301,6 +380,11 @@ def build_chat_trace(
                 "generation_ms": timing.get("generation_ms"),
                 "ttfb_ms": timing.get("ttfb_ms"),
                 "token_estimate": token_estimate,
+                **(
+                    {"prompt_chars": chat_gen_rec.get("prompt_chars")}
+                    if chat_gen_rec
+                    else {}
+                ),
                 **({"error": generation_error} if llm_failed else {}),
             },
         )
@@ -385,6 +469,9 @@ def build_chat_trace(
             status=_edge_status(downstream_status),
         )
     )
+
+    # --- 補助 LLM ノード (collector 由来) ---
+    _append_aux_llm_nodes(nodes, edges, llm_calls)
 
     trace_id = f"turn_{turn_id}" if turn_id is not None else "turn_unknown"
     return TraceGraph(

--- a/butly_core/trace/collector.py
+++ b/butly_core/trace/collector.py
@@ -1,0 +1,96 @@
+"""
+collector.py
+------------
+1 ターン中の LLM 呼び出しを ContextVar 経由で収集する軽量コレクター (issue #51)。
+
+ChatService がターン開始時に ``start_collection()`` を呼び、ターン終了時に
+try/finally で ``reset_collection(token)`` する。補助 LLM の呼び出し元
+(ContextClassifier / StateUpdater / Brain 等) は ``record_llm_call()`` を
+1 行呼ぶだけでよい。収集が開始されていない文脈 (sleeptime、単体テスト等)
+では record は no-op になり、副作用を持たない。
+
+並列実行との相性:
+    ContextVar には可変 list を入れる。``run_in_threadpool`` (anyio) や
+    ``asyncio.create_task`` は context を **コピー** するが、コピーされるのは
+    ContextVar → 値 のマッピングであり list オブジェクト自体は共有される。
+    そのため並列タスク / worker thread からの append も同じ list に届く
+    (list.append は GIL 下で atomic)。
+"""
+
+import time
+from contextvars import ContextVar, Token
+from typing import Any, Dict, List, Optional
+
+_llm_calls: ContextVar[Optional[List[Dict[str, Any]]]] = ContextVar(
+    "butly_trace_llm_calls", default=None
+)
+
+
+def start_collection() -> Token:
+    """収集を開始し、reset 用の Token を返す。
+
+    呼び出し側は必ず try/finally で ``reset_collection(token)`` すること。
+    ``execute_stream`` のような async generator では、generator 全体を包む
+    位置 (最初の処理の前 / finally) に置く。
+    """
+    return _llm_calls.set([])
+
+
+def reset_collection(token: Token) -> None:
+    """収集を終了する。
+
+    async generator が別 context で close された場合など、Token が現在の
+    context と一致しないことがある。収集はターン単位の使い捨てなので、
+    その場合はログだけ残して無視する。
+    """
+    try:
+        _llm_calls.reset(token)
+    except ValueError as e:
+        print(f"[TraceCollector] reset をスキップ (context 不一致、無害): {e}")
+
+
+def is_collecting() -> bool:
+    """現在の context で収集中かを返す。"""
+    return _llm_calls.get() is not None
+
+
+def get_collected() -> List[Dict[str, Any]]:
+    """収集済みの LLM 呼び出し記録のコピーを返す (未開始なら空リスト)。"""
+    calls = _llm_calls.get()
+    return list(calls) if calls is not None else []
+
+
+def record_llm_call(
+    *,
+    purpose: str,
+    model: str = "",
+    connection_id: str = "",
+    duration_ms: Optional[int] = None,
+    prompt_chars: Optional[int] = None,
+    error: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> None:
+    """LLM 呼び出し 1 件を記録する。収集未開始なら no-op。
+
+    Parameters
+    ----------
+    purpose : str
+        呼び出しの目的。trace のノード分類・表示フィルタのキーになる。
+        既知の値: "context_classifier" / "state_updater" / "embedding" /
+        "keyword_extract" / "chat_generate"。
+    """
+    calls = _llm_calls.get()
+    if calls is None:
+        return
+    entry: Dict[str, Any] = {
+        "purpose": purpose,
+        "model": model,
+        "connection_id": connection_id,
+        "duration_ms": duration_ms,
+        "prompt_chars": prompt_chars,
+        "error": error,
+        "recorded_at": time.time(),
+    }
+    if metadata:
+        entry["metadata"] = metadata
+    calls.append(entry)

--- a/butly_core/trace/filters.py
+++ b/butly_core/trace/filters.py
@@ -1,0 +1,56 @@
+"""
+filters.py
+----------
+TraceGraph の表示フィルタ (issue #51)。
+
+trace.json には常に全ノードを保存し、表示側 (Mermaid / 将来の Debug UI) で
+このフィルタを適用する。収集を設定で止めると「問題が起きたターンに限って
+データがない」状態になるため、設定 (``SYSTEM_CONFIG["trace"]``) の
+``detail`` / ``hidden_nodes`` は保存ではなく表示に効かせる。
+"""
+
+from typing import Sequence
+
+from butly_core.trace.types import TraceGraph, TraceNode
+
+
+def _is_hidden(node: TraceNode, detail: str, hidden: set) -> bool:
+    if detail == "summary" and node.metadata.get("aux"):
+        return True
+    if node.id in hidden:
+        return True
+    purpose = node.metadata.get("purpose")
+    return purpose in hidden if purpose else False
+
+
+def filter_trace(
+    trace: TraceGraph,
+    *,
+    detail: str = "full",
+    hidden_nodes: Sequence[str] = (),
+) -> TraceGraph:
+    """表示用にノードを絞った TraceGraph のコピーを返す。
+
+    Parameters
+    ----------
+    detail : str
+        "full" (既定) は全ノード。"summary" は補助 LLM ノード
+        (``metadata.aux=True``) を除いたメインフローのみ。
+    hidden_nodes : Sequence[str]
+        非表示にするノードの purpose (例: "embedding", "keyword_extract")
+        または node id (例: "web_search")。embedding のように同一 purpose が
+        複数ノードになるものは purpose 指定でまとめて隠せる。
+
+    非表示ノードに接続するエッジも取り除く。メインフローの中間ノードを隠すと
+    グラフが分断され得るため、主用途は補助 LLM ノード (葉) の非表示。
+    """
+    hidden = set(hidden_nodes or ())
+    if not hidden and detail == "full":
+        return trace
+
+    kept_nodes = [n for n in trace.nodes if not _is_hidden(n, detail, hidden)]
+    kept_ids = {n.id for n in kept_nodes}
+    kept_edges = [
+        e for e in trace.edges if e.source in kept_ids and e.target in kept_ids
+    ]
+    return trace.model_copy(update={"nodes": kept_nodes, "edges": kept_edges})

--- a/butly_core/trace/mermaid.py
+++ b/butly_core/trace/mermaid.py
@@ -73,8 +73,22 @@ def _edge_line(edge: TraceEdge) -> str:
     return f"    {edge.source} {connector} {edge.target}"
 
 
-def render_mermaid(trace: TraceGraph, *, direction: str = "TD") -> str:
-    """TraceGraph を Mermaid flowchart 文字列へ変換する。"""
+def render_mermaid(
+    trace: TraceGraph,
+    *,
+    direction: str = "TD",
+    detail: str = "full",
+    hidden_nodes=(),
+) -> str:
+    """TraceGraph を Mermaid flowchart 文字列へ変換する。
+
+    ``detail`` / ``hidden_nodes`` は ``filter_trace()`` に委譲する表示フィルタ。
+    SYSTEM_CONFIG["trace"] の同名設定を呼び出し側 (Debug UI 等) が渡す想定。
+    """
+    from butly_core.trace.filters import filter_trace
+
+    trace = filter_trace(trace, detail=detail, hidden_nodes=hidden_nodes)
+
     lines: List[str] = [f"flowchart {direction}"]
 
     for node in trace.nodes:

--- a/docs/reference/FILE_STRUCTURE.ja.md
+++ b/docs/reference/FILE_STRUCTURE.ja.md
@@ -168,7 +168,7 @@ FastAPI のルーターモジュール群。各ルーターは `dependencies.py`
 - `_write_rotating_json(target_dir, payload, max_history, *, log_label)` — `latest.json` + `history/{ts}.json` ローテーション書き出しの共通ヘルパー
 - `_save_debug_log(instance_dir, payload, max_history=20)` — `debug_logs/` へデバッグ情報を保存
 - `_save_trace(instance_dir, trace_payload, max_history=20)` — `traces/` へ Trace Graph (trace.json) を保存
-- `_build_and_save_trace(...)` — 実行事実から `build_chat_trace()` で TraceGraph を構築し `_save_trace` で保存（issue #51。構築/保存失敗は応答に影響させない）
+- `_build_and_save_trace(...)` — 実行事実 + collector の `llm_calls` から `build_chat_trace()` で TraceGraph を構築し `_save_trace` で保存（issue #51。`SYSTEM_CONFIG["trace"].enabled=false` で保存スキップ。構築/保存失敗は応答に影響させない）。`execute()` / `execute_stream()` は本体全体を `start_collection()` / `reset_collection()`（try/finally）で包む
 
 ---
 
@@ -188,20 +188,45 @@ Trace Graph の DTO（Pydantic モデル）と定数・ヘルパー。
 - `TRACE_SCHEMA_VERSION` — trace.json スキーマのバージョン
 - `summarize_text(text, limit=80)` — summary 用にテキストを 1 行へ切り詰める（長文をそのまま残さないための長さ切り詰め。PII 除去・匿名化ではない）
 
-### `butly_core/trace/builder.py`
-ChatService の実行事実（gatekeeper 出力・記憶ブロック・Provider 情報・timing 等）から
-`TraceGraph` を再構成する純粋関数。並列実行される生成フローへ span logger を差し込まず、
-確定済みの状態から組み立てることで P0 のチャット経路を変更しない。
+### `butly_core/trace/collector.py`
+1 ターン中の **全 LLM 呼び出し**を ContextVar 経由で収集する軽量コレクター。
+ContextVar に可変 list を入れることで、`run_in_threadpool` / `asyncio.create_task` へ
+コピーされた context からも同じ list に append が届く（並列生成 + StateUpdater 対応）。
 
-- `build_chat_trace(...)` — `user_message → gatekeeper → (memory_probe / rag / web_search) → context_assembly → provider → llm_call → memory_write → state_update / response` のノードとエッジを構築。RAG 未注入・Web 検索 OFF・Gatekeeper フォールバック等を status で表現する
+- `start_collection()` — 収集開始。reset 用 Token を返す（ChatService が try/finally で使用）
+- `reset_collection(token)` — 収集終了。context 不一致時はログのみで無害
+- `record_llm_call(*, purpose, model, connection_id, duration_ms, prompt_chars, error, metadata)` — 1 呼び出しを記録。**収集未開始なら no-op**（sleeptime 等には副作用なし）
+- `get_collected()` / `is_collecting()`
+
+**記録ポイント（purpose）:** `context_classifier`（ContextClassifier.classify）/ `state_updater`（StateUpdater.update）/ `embedding`（ButlyBrain.get_embedding）/ `keyword_extract`（ButlyBrain.extract_keywords）/ `chat_generate`（ChatService の main 生成・stream 両方）
+
+### `butly_core/trace/builder.py`
+ChatService の実行事実（gatekeeper 出力・記憶ブロック・Provider 情報・timing・collector の
+`llm_calls`）から `TraceGraph` を再構成する純粋関数。
+
+- `build_chat_trace(..., llm_calls=None)` — `user_message → gatekeeper → (memory_probe / rag / web_search) → context_assembly → provider → llm_call → memory_write → state_update / response` のノードとエッジを構築。RAG 未注入・Web 検索 OFF・Gatekeeper フォールバック・LLM 生成失敗（`generation_error`）等を status で表現する
+- 補助 LLM ノード: `llm_calls` の記録から `llm_context_classifier` / `llm_embedding`（複数回は連番）/ `llm_keyword_extract` / `llm_state_updater` を親ノード（gatekeeper / memory_probe / state_update）にぶら下げて生成。`metadata.aux=True` + `metadata.purpose` を持つ。**main 生成（chat_generate）は新ノードにせず既存 `llm_call` の metadata（prompt_chars 等）を拡充する**
+
+### `butly_core/trace/filters.py`
+表示フィルタ。**trace.json には常に全ノードを保存**し、表示側でこのフィルタを適用する。
+
+- `filter_trace(trace, *, detail="full", hidden_nodes=())` — `detail="summary"` で補助 LLM ノード（`metadata.aux`）を除外。`hidden_nodes` は **purpose**（例: `"embedding"` で全 embedding ノード）または node id（例: `"web_search"`）で指定
 
 ### `butly_core/trace/mermaid.py`
 `TraceGraph` を Mermaid flowchart 文字列へ変換する軽量レンダラー。
 
-- `render_mermaid(trace, *, direction="TD")` — ノード宣言 + エッジ + classDef を出力。active/skipped/fallback/error/warning を色分けし、skipped/fallback/error のエッジは線種で区別する
+- `render_mermaid(trace, *, direction="TD", detail="full", hidden_nodes=())` — `filter_trace` を適用後、ノード宣言 + エッジ + classDef を出力。active/skipped/fallback/error/warning を色分けし、skipped/fallback/error のエッジは線種で区別する
 - `_sanitize(text)` — Mermaid ラベル構文を壊す文字（`"` `[` `]` 等）を置換
 
 **保存先:** `butly_core/instances/{instance}/traces/latest.json` + `traces/history/{ts}.json`（debug_logs と同じローテーション方式。再構築可能な telemetry のため atomic write 対象外）。
+
+**設定（`SYSTEM_CONFIG["trace"]` / `get_settings().system.trace`）:**
+
+| キー | デフォルト | 説明 |
+|---|---|---|
+| `enabled` | `true` | trace.json の**保存** ON/OFF |
+| `detail` | `"full"` | 表示フィルタ。`"summary"` で補助 LLM ノードを非表示（保存は常に full） |
+| `hidden_nodes` | `[]` | 表示フィルタ。purpose / node id で個別非表示 |
 
 ---
 

--- a/docs/reference/FILE_STRUCTURE.md
+++ b/docs/reference/FILE_STRUCTURE.md
@@ -91,13 +91,17 @@ Stateless orchestrator with two entry points:
 
 ### `butly_core/trace/`
 
-Trace Graph (issue #51): records and visualizes the answer-generation flow as a node + edge graph. Frontend-independent — covers `trace.json` persistence and Mermaid generation only.
+Trace Graph (issue #51): records and visualizes the answer-generation flow as a node + edge graph. Frontend-independent — covers LLM-call collection, `trace.json` persistence, and Mermaid generation.
 
 - `types.py` — Pydantic DTOs: `TraceNode`, `TraceEdge` (serialized with `from`/`to` keys), `TraceGraph`; `NodeType`, `TraceStatus` (`active`/`skipped`/`fallback`/`error`/`warning`), `summarize_text()`.
-- `builder.py` — `build_chat_trace(...)`: pure function reconstructing the graph (`user_message → gatekeeper → memory_probe/rag/web_search → context_assembly → provider → llm_call → memory_write → state_update/response`) from collected facts, without instrumenting the parallel generation path.
-- `mermaid.py` — `render_mermaid(trace, *, direction="TD")`: lightweight renderer; colors nodes by status and distinguishes skipped/fallback/error edges by line style.
+- `collector.py` — ContextVar-based per-turn LLM call collector. A mutable list in the ContextVar is shared across `run_in_threadpool` / `asyncio.create_task` context copies, so parallel generation + StateUpdater both record into it. `record_llm_call()` is a no-op when collection is not started. Record points (purpose): `context_classifier`, `state_updater`, `embedding`, `keyword_extract`, `chat_generate`.
+- `builder.py` — `build_chat_trace(..., llm_calls=None)`: pure function reconstructing the graph (`user_message → gatekeeper → memory_probe/rag/web_search → context_assembly → provider → llm_call → memory_write → state_update/response`) from collected facts. Auxiliary LLM nodes (`llm_context_classifier`, `llm_embedding` (numbered when repeated), `llm_keyword_extract`, `llm_state_updater`) hang off their parent stage with `metadata.aux=True` + `metadata.purpose`; the main generation enriches the existing `llm_call` node instead of adding a new one.
+- `filters.py` — `filter_trace(trace, *, detail, hidden_nodes)`: display filter. `trace.json` always stores the full graph; `detail="summary"` hides aux LLM nodes, `hidden_nodes` matches by purpose (e.g. `"embedding"`) or node id.
+- `mermaid.py` — `render_mermaid(trace, *, direction="TD", detail="full", hidden_nodes=())`: applies `filter_trace`, then renders; colors nodes by status and distinguishes skipped/fallback/error edges by line style.
 
 Saved to `butly_core/instances/{instance}/traces/latest.json` + `traces/history/{ts}.json` (same rotation as `debug_logs`; reconstructible telemetry, so not atomic-write).
+
+Settings (`SYSTEM_CONFIG["trace"]` / `get_settings().system.trace`): `enabled` (save on/off, default `true`), `detail` / `hidden_nodes` (display filters; storage is always full).
 
 ---
 

--- a/tests/test_chat_stream.py
+++ b/tests/test_chat_stream.py
@@ -152,6 +152,13 @@ class TestExecuteStream:
             "mid", history_msgs=[]
         )
 
+        # issue #51: collector 経由の chat_generate 記録が trace.json に反映される
+        trace = json.loads(
+            (tmp_instance_dir / "traces" / "latest.json").read_text(encoding="utf-8")
+        )
+        llm_node = next(n for n in trace["nodes"] if n["id"] == "llm_call")
+        assert llm_node["metadata"]["prompt_chars"] > 0
+
     def test_provider_error_yields_error_event(
         self, tmp_instance_dir, request_obj, mock_components,
         mock_instance_manager, mock_gatekeeper, mock_mem_builder,

--- a/tests/test_trace_collector.py
+++ b/tests/test_trace_collector.py
@@ -1,0 +1,454 @@
+"""
+test_trace_collector.py
+-----------------------
+Trace Graph の LLM 呼び出し収集 (issue #51 拡張) のユニットテスト。
+
+- collector: start/reset/record/get、並列タスク・thread からの記録、no-op
+- 記録ポイント: ContextClassifier / StateUpdater / Brain (embedding, keywords)
+- builder: llm_calls → 補助 LLM ノード生成、chat_generate の llm_call 統合
+- filters: detail="summary" / hidden_nodes (purpose・node id)
+- 設定: SYSTEM_CONFIG["trace"].enabled=False で trace.json を保存しない
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from butly_core.trace import (
+    build_chat_trace,
+    filter_trace,
+    get_collected,
+    is_collecting,
+    record_llm_call,
+    render_mermaid,
+    reset_collection,
+    start_collection,
+)
+
+
+def _base_trace_kwargs(**overrides):
+    base = dict(
+        instance_name="x",
+        user_input="hi",
+        assistant_response="ok",
+        gk_result={
+            "tier": "mid",
+            "need": "past_fact",
+            "memory_probe": {"status": "hit", "candidates": [], "glossary_hits": []},
+            "state_delta": {"topic": "t"},
+        },
+        tier="mid",
+        memory_blocks={"short_term": [1]},
+        gk_enabled=True,
+        connection_id="openai",
+        model_name="gpt-4o",
+        provider_name="OpenAIProvider",
+        timing={"generation_ms": 1500},
+        token_estimate={},
+        turn_id=1,
+    )
+    base.update(overrides)
+    return base
+
+
+# ===================================================================
+# collector
+# ===================================================================
+
+
+class TestCollector:
+    def test_record_is_noop_when_not_started(self):
+        record_llm_call(purpose="embedding", model="m")
+        assert get_collected() == []
+        assert not is_collecting()
+
+    def test_start_record_reset(self):
+        token = start_collection()
+        try:
+            assert is_collecting()
+            record_llm_call(
+                purpose="context_classifier",
+                model="flash",
+                duration_ms=100,
+                prompt_chars=500,
+            )
+            calls = get_collected()
+            assert len(calls) == 1
+            assert calls[0]["purpose"] == "context_classifier"
+            assert calls[0]["duration_ms"] == 100
+            assert calls[0]["error"] is None
+        finally:
+            reset_collection(token)
+        assert not is_collecting()
+        assert get_collected() == []
+
+    def test_get_collected_returns_copy(self):
+        token = start_collection()
+        try:
+            record_llm_call(purpose="embedding")
+            snapshot = get_collected()
+            snapshot.append({"purpose": "fake"})
+            assert len(get_collected()) == 1
+        finally:
+            reset_collection(token)
+
+    def test_parallel_tasks_and_threads_share_list(self):
+        """asyncio.gather の並列タスクと thread からの記録が同じ list に届く。"""
+
+        async def main():
+            token = start_collection()
+            try:
+                record_llm_call(purpose="context_classifier")
+
+                async def task_record():
+                    record_llm_call(purpose="state_updater")
+
+                async def thread_record():
+                    await asyncio.to_thread(record_llm_call, purpose="embedding")
+
+                await asyncio.gather(
+                    asyncio.create_task(task_record()), thread_record()
+                )
+                record_llm_call(purpose="chat_generate")
+                return get_collected()
+            finally:
+                reset_collection(token)
+
+        calls = asyncio.run(main())
+        purposes = {c["purpose"] for c in calls}
+        assert purposes == {
+            "context_classifier",
+            "state_updater",
+            "embedding",
+            "chat_generate",
+        }
+
+    def test_nested_collection_restores_outer(self):
+        outer = start_collection()
+        try:
+            record_llm_call(purpose="embedding")
+            inner = start_collection()
+            record_llm_call(purpose="keyword_extract")
+            assert [c["purpose"] for c in get_collected()] == ["keyword_extract"]
+            reset_collection(inner)
+            assert [c["purpose"] for c in get_collected()] == ["embedding"]
+        finally:
+            reset_collection(outer)
+
+
+# ===================================================================
+# 記録ポイント (実モジュール + mock provider)
+# ===================================================================
+
+
+@pytest.fixture
+def collection():
+    token = start_collection()
+    yield
+    reset_collection(token)
+
+
+class TestRecordPoints:
+    def test_context_classifier_records(self, collection):
+        from butly_core.core.gatekeeper.context_classifier import ContextClassifier
+
+        provider = MagicMock()
+        provider.classify.return_value = (
+            '```json{"llm_scoring": {"response_complexity": 0.2, '
+            '"emotional_weight": 0.1, "continuity_need": 0.1}, '
+            '"need_intent": null}```'
+        )
+        with patch(
+            "butly_core.llm.factory.ProviderFactory.create", return_value=provider
+        ):
+            ContextClassifier().classify("こんにちは", [])
+
+        calls = [c for c in get_collected() if c["purpose"] == "context_classifier"]
+        assert len(calls) == 1
+        assert calls[0]["error"] is None
+        assert calls[0]["prompt_chars"] > 0
+        assert calls[0]["duration_ms"] >= 0
+
+    def test_context_classifier_records_error(self, collection):
+        from butly_core.core.gatekeeper.context_classifier import ContextClassifier
+
+        with patch(
+            "butly_core.llm.factory.ProviderFactory.create",
+            side_effect=RuntimeError("api down"),
+        ):
+            result = ContextClassifier().classify("こんにちは", [])
+
+        assert result["tier"] == "mid"  # フォールバック動作は不変
+        calls = [c for c in get_collected() if c["purpose"] == "context_classifier"]
+        assert len(calls) == 1
+        assert "api down" in calls[0]["error"]
+
+    def test_state_updater_records(self, collection):
+        from butly_core.core.gatekeeper.state_updater import StateUpdater
+
+        provider = MagicMock()
+        provider.classify.return_value = '```json{"topic": "旅行", "mood": null}```'
+        with patch(
+            "butly_core.llm.factory.ProviderFactory.create", return_value=provider
+        ):
+            StateUpdater().update("沖縄いきたい", [], {"topic": "", "mood": "neutral"})
+
+        calls = [c for c in get_collected() if c["purpose"] == "state_updater"]
+        assert len(calls) == 1
+        assert calls[0]["error"] is None
+
+    def test_brain_embedding_records(self, collection, tmp_path):
+        from butly_core.core.brain import ButlyBrain
+
+        brain = ButlyBrain(tmp_path)
+        provider = MagicMock()
+        provider.embed.return_value = [0.1, 0.2]
+        with patch.object(brain, "_get_provider", return_value=provider):
+            assert brain.get_embedding("テキスト") == [0.1, 0.2]
+
+        calls = [c for c in get_collected() if c["purpose"] == "embedding"]
+        assert len(calls) == 1
+        assert calls[0]["prompt_chars"] == len("テキスト")
+
+    def test_brain_embedding_records_error(self, collection, tmp_path):
+        from butly_core.core.brain import ButlyBrain
+
+        brain = ButlyBrain(tmp_path)
+        with patch.object(
+            brain, "_get_provider", side_effect=RuntimeError("embed down")
+        ):
+            assert brain.get_embedding("t") is None
+
+        calls = [c for c in get_collected() if c["purpose"] == "embedding"]
+        assert len(calls) == 1
+        assert "embed down" in calls[0]["error"]
+
+    def test_brain_keyword_extract_records_once_on_parse_failure(
+        self, collection, tmp_path
+    ):
+        """LLM 呼び出しは成功、後段の JSON パースが失敗 → error なしで 1 件記録。"""
+        from butly_core.core.brain import ButlyBrain
+
+        brain = ButlyBrain(tmp_path)
+        provider = MagicMock()
+        provider.classify.return_value = "not a json"
+        with patch.object(brain, "_get_provider", return_value=provider):
+            assert brain.extract_keywords("hello") == {"keywords": []}
+
+        calls = [c for c in get_collected() if c["purpose"] == "keyword_extract"]
+        assert len(calls) == 1
+        assert calls[0]["error"] is None
+
+    def test_brain_keyword_extract_records_call_error(self, collection, tmp_path):
+        from butly_core.core.brain import ButlyBrain
+
+        brain = ButlyBrain(tmp_path)
+        provider = MagicMock()
+        provider.classify.side_effect = RuntimeError("classify down")
+        with patch.object(brain, "_get_provider", return_value=provider):
+            assert brain.extract_keywords("hello") == {"keywords": []}
+
+        calls = [c for c in get_collected() if c["purpose"] == "keyword_extract"]
+        assert len(calls) == 1
+        assert "classify down" in calls[0]["error"]
+
+
+# ===================================================================
+# builder: 補助 LLM ノード
+# ===================================================================
+
+
+def _sample_calls():
+    return [
+        {
+            "purpose": "context_classifier",
+            "model": "flash",
+            "connection_id": "google",
+            "duration_ms": 120,
+            "prompt_chars": 800,
+            "error": None,
+        },
+        {
+            "purpose": "embedding",
+            "model": "emb-2",
+            "connection_id": "google",
+            "duration_ms": 40,
+            "prompt_chars": 20,
+            "error": None,
+        },
+        {
+            "purpose": "embedding",
+            "model": "emb-2",
+            "connection_id": "google",
+            "duration_ms": 42,
+            "prompt_chars": 25,
+            "error": None,
+        },
+        {
+            "purpose": "state_updater",
+            "model": "flash",
+            "connection_id": "google",
+            "duration_ms": 95,
+            "prompt_chars": 400,
+            "error": "boom",
+        },
+        {
+            "purpose": "chat_generate",
+            "model": "gpt-4o",
+            "connection_id": "openai",
+            "duration_ms": 1500,
+            "prompt_chars": 5000,
+            "error": None,
+        },
+    ]
+
+
+class TestBuilderAuxNodes:
+    def test_aux_nodes_created_with_parents(self):
+        trace = build_chat_trace(**_base_trace_kwargs(llm_calls=_sample_calls()))
+        ids = [n.id for n in trace.nodes]
+        assert "llm_context_classifier" in ids
+        assert "llm_embedding" in ids
+        assert "llm_embedding_2" in ids  # 同一 purpose は連番
+        assert "llm_state_updater" in ids
+        assert "llm_chat_generate" not in ids  # main は既存 llm_call に統合
+
+        edges = {(e.source, e.target) for e in trace.edges}
+        assert ("gatekeeper", "llm_context_classifier") in edges
+        assert ("memory_probe", "llm_embedding") in edges
+        assert ("state_update", "llm_state_updater") in edges
+
+    def test_aux_node_error_status(self):
+        trace = build_chat_trace(**_base_trace_kwargs(llm_calls=_sample_calls()))
+        su = next(n for n in trace.nodes if n.id == "llm_state_updater")
+        assert su.status == "error"
+        assert su.metadata["error"] == "boom"
+
+    def test_aux_metadata_and_flag(self):
+        trace = build_chat_trace(**_base_trace_kwargs(llm_calls=_sample_calls()))
+        cc = next(n for n in trace.nodes if n.id == "llm_context_classifier")
+        assert cc.metadata["aux"] is True
+        assert cc.metadata["purpose"] == "context_classifier"
+        assert cc.metadata["duration_ms"] == 120
+        assert "flash" in cc.summary and "120ms" in cc.summary
+
+    def test_chat_generate_enriches_llm_call(self):
+        trace = build_chat_trace(**_base_trace_kwargs(llm_calls=_sample_calls()))
+        llm = next(n for n in trace.nodes if n.id == "llm_call")
+        assert llm.metadata["prompt_chars"] == 5000
+
+    def test_no_llm_calls_keeps_main_flow_only(self):
+        trace = build_chat_trace(**_base_trace_kwargs(llm_calls=None))
+        assert not any(n.metadata.get("aux") for n in trace.nodes)
+
+    def test_unknown_purpose_attaches_to_llm_call(self):
+        calls = [{"purpose": "mcp_tool", "model": "m", "duration_ms": 5}]
+        trace = build_chat_trace(**_base_trace_kwargs(llm_calls=calls))
+        assert any(n.id == "llm_mcp_tool" for n in trace.nodes)
+        edges = {(e.source, e.target) for e in trace.edges}
+        assert ("llm_call", "llm_mcp_tool") in edges
+
+
+# ===================================================================
+# filters / mermaid 表示
+# ===================================================================
+
+
+class TestFilters:
+    def _trace(self):
+        return build_chat_trace(**_base_trace_kwargs(llm_calls=_sample_calls()))
+
+    def test_full_is_passthrough(self):
+        t = self._trace()
+        assert filter_trace(t) is t
+
+    def test_summary_hides_aux_nodes(self):
+        t = filter_trace(self._trace(), detail="summary")
+        assert not any(n.metadata.get("aux") for n in t.nodes)
+        # メインフローは残る
+        ids = {n.id for n in t.nodes}
+        assert {"user_message", "gatekeeper", "llm_call", "response"} <= ids
+
+    def test_hidden_by_purpose_hides_all_instances(self):
+        t = filter_trace(self._trace(), hidden_nodes=["embedding"])
+        ids = {n.id for n in t.nodes}
+        assert "llm_embedding" not in ids and "llm_embedding_2" not in ids
+        assert "llm_context_classifier" in ids
+
+    def test_hidden_by_node_id(self):
+        t = filter_trace(self._trace(), hidden_nodes=["web_search"])
+        assert "web_search" not in {n.id for n in t.nodes}
+        assert not any("web_search" in (e.source, e.target) for e in t.edges)
+
+    def test_render_mermaid_applies_filters(self):
+        full = render_mermaid(self._trace())
+        summary = render_mermaid(self._trace(), detail="summary")
+        hidden = render_mermaid(self._trace(), hidden_nodes=["embedding"])
+        assert "llm_context_classifier" in full
+        assert "llm_context_classifier" not in summary
+        assert "llm_embedding" not in hidden
+        assert "llm_context_classifier" in hidden
+
+
+# ===================================================================
+# 設定: trace.enabled=False で保存しない
+# ===================================================================
+
+
+class TestTraceSettingsGate:
+    def test_trace_section_in_defaults(self):
+        from butly_core.settings import SystemConfig
+
+        cfg = SystemConfig()
+        assert cfg.trace.get("enabled") is True
+        assert cfg.trace.get("detail") == "full"
+        assert cfg.trace.get("hidden_nodes") == []
+
+    def test_disabled_skips_save(self, tmp_path):
+        from butly_core.chat.service import _build_and_save_trace
+        from butly_core.settings import (
+            RootSettings,
+            SystemConfig,
+            override_settings,
+        )
+
+        instance_dir = tmp_path / "Inst"
+        instance_dir.mkdir()
+        prepared = MagicMock()
+        prepared.memory_blocks = {}
+        prepared.gk_enabled = True
+        prepared.gk_error = None
+        prepared.web_search_status = ""
+        prepared.web_search_count = 0
+        prepared.has_attachments = False
+        request = MagicMock()
+        request.text = "hi"
+        request.source = "web"
+        session_state = MagicMock()
+        session_state.to_dict.return_value = {"turn_count": 1}
+
+        common = dict(
+            instance_dir=instance_dir,
+            instance_name="Inst",
+            request=request,
+            prepared=prepared,
+            tier="mid",
+            gk_result={"state_delta": {}},
+            assistant_response="ok",
+            debug_info={"timing": {}, "token_estimate": {}},
+            session_state=session_state,
+            provider=MagicMock(),
+            connection_id="openai",
+            model_name="gpt-4o",
+        )
+
+        disabled = RootSettings(system=SystemConfig(trace={"enabled": False}))
+        with override_settings(disabled):
+            _build_and_save_trace(**common)
+        assert not (instance_dir / "traces").exists()
+
+        enabled = RootSettings(system=SystemConfig(trace={"enabled": True}))
+        with override_settings(enabled):
+            _build_and_save_trace(**common)
+        assert (instance_dir / "traces" / "latest.json").exists()


### PR DESCRIPTION
ContextVarベースの軽量コレクター(trace/collector.py)を追加し、1ターン中の 補助LLM呼び出しを収集してTrace Graphの個別ノードとして可視化する。

- collector: start/reset(token, try/finally) + record_llm_call。収集未開始は no-op。ContextVarに可変listを持たせ、run_in_threadpool / create_task の 並列実行からも同一listへ記録される
- 記録ポイント5箇所: ContextClassifier.classify / StateUpdater.update / Brain.get_embedding / Brain.extract_keywords / ChatService main生成 (execute + stream)。既存のフォールバック挙動は不変
- builder: llm_calls から補助LLMノード(llm_context_classifier / llm_embedding(連番) / llm_keyword_extract / llm_state_updater)を親ステージ にぶら下げて生成。main生成は既存 llm_call ノードのmetadata拡充に統合
- filters: filter_trace(detail / hidden_nodes)。hidden_nodesはpurposeまたは node idで指定。render_mermaidにも同パラメータを追加
- 設定: SYSTEM_CONFIG["trace"] (enabled=保存ON/OFF、detail / hidden_nodes= 表示フィルタ)。保存は常にfull、表示側でフィルタする方針