### PR TITLE
fix: tighten frontend phase 0 contracts

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import base64
 from datetime import datetime
 from pathlib import Path
 import asyncio
+import os
 
 # 自作モジュールのインポート
 from butly_core.core.memory import ButlyMemory
@@ -324,8 +325,14 @@ def initialize_system(base_dir, instance_name):
 if not INSTANCES_DIR.exists():
     INSTANCES_DIR.mkdir(parents=True, exist_ok=True)
 
+def normalize_api_url(api_url: str) -> str:
+    return api_url.strip().rstrip("/") or "http://127.0.0.1:8000"
+
+
 # デフォルトAPI接続先（session_state 初期化前のモジュールレベルでも使う）
-DEFAULT_API_URL = "http://127.0.0.1:8000"
+DEFAULT_API_URL = normalize_api_url(
+    os.environ.get("BUTLY_API_URL", "http://127.0.0.1:8000")
+)
 
 
 def fetch_instance_names(api_url: str) -> list:
@@ -337,6 +344,7 @@ def fetch_instance_names(api_url: str) -> list:
     """
     import requests as _req_inst
 
+    api_url = normalize_api_url(api_url)
     resp = _req_inst.get(f"{api_url}/api/v1/instances", timeout=5)
     resp.raise_for_status()
     items = resp.json().get("items", [])
@@ -347,18 +355,22 @@ def fetch_instance_names(api_url: str) -> list:
     )
 
 
-try:
-    available_instances = fetch_instance_names(DEFAULT_API_URL)
-except Exception as _e_inst:
-    st.error(
-        f"Butly API（{DEFAULT_API_URL}）に接続できません: {_e_inst}\n\n"
-        "FastAPI サーバー（main.py）が起動しているか確認してください。"
-    )
-    st.stop()
-
 # --- セッションステートの初期化 ---
 if "current_page" not in st.session_state:
     st.session_state.current_page = "home"
+# API接続先（DEFAULT_API_URL はモジュール先頭で定義済み）
+if "api_base_url" not in st.session_state:
+    st.session_state.api_base_url = DEFAULT_API_URL
+if "api_connection_error" not in st.session_state:
+    st.session_state.api_connection_error = None
+
+try:
+    available_instances = fetch_instance_names(st.session_state.api_base_url)
+    st.session_state.api_connection_error = None
+except Exception as _e_inst:
+    available_instances = []
+    st.session_state.api_connection_error = str(_e_inst)
+
 if "current_instance" not in st.session_state:
     st.session_state.current_instance = (
         available_instances[0] if available_instances else None
@@ -378,9 +390,6 @@ if "input_key_counter" not in st.session_state:
     st.session_state.input_key_counter = 0  # チャット入力欄クリア用
 if "pending_attachments" not in st.session_state:
     st.session_state.pending_attachments = []
-# API接続先（DEFAULT_API_URL はモジュール先頭で定義済み）
-if "api_base_url" not in st.session_state:
-    st.session_state.api_base_url = DEFAULT_API_URL
 # テーマカラー (Butlyアプリ対応)
 if "theme_color" not in st.session_state:
     st.session_state.theme_color = "teal"
@@ -485,7 +494,14 @@ def render_home_screen():
 
     # インスタンス一覧
     st.subheader("Your AI Instances")
-    if not available_instances:
+    api_error = st.session_state.get("api_connection_error")
+    if api_error:
+        st.error(
+            f"Butly API（{st.session_state.api_base_url}）に接続できません: "
+            f"{api_error}\n\n"
+            "FastAPI サーバー（main.py）が起動しているか、設定の API 接続先を確認してください。"
+        )
+    elif not available_instances:
         st.write("インスタンスがありません。")
     else:
         for name in available_instances:
@@ -721,8 +737,11 @@ def render_settings_screen():
             placeholder="http://127.0.0.1:8000",
         )
         if st.button("💾 接続先を保存", key="save_url"):
-            st.session_state.api_base_url = new_url
-            st.success(f"接続先を {new_url} に変更しました。")
+            normalized_url = normalize_api_url(new_url)
+            st.session_state.api_base_url = normalized_url
+            st.session_state.api_connection_error = None
+            st.success(f"接続先を {normalized_url} に変更しました。")
+            st.rerun()
 
         st.divider()
         st.subheader("🏖️ Holiday Mode (休暇設定)")
@@ -3530,19 +3549,23 @@ def main():
         available_instances = fetch_instance_names(
             st.session_state.get("api_base_url", DEFAULT_API_URL)
         )
+        st.session_state.api_connection_error = None
     except Exception as e:
-        st.error(
-            f"Butly API からインスタンス一覧を取得できません: {e}\n\n"
-            "FastAPI サーバー（main.py）が起動しているか確認してください。"
-        )
-        st.stop()
+        available_instances = []
+        st.session_state.api_connection_error = str(e)
 
     if not available_instances:
+        if st.session_state.current_page not in {"home", "settings"}:
+            st.session_state.current_page = "home"
+            st.session_state.current_instance = None
         # インスタンス未作成でもホーム画面を表示（新規作成UIがホーム画面にある）
+        if st.session_state.current_page == "settings":
+            render_settings_screen()
+            return
         render_home_screen()
         return
 
-    if st.session_state.current_instance is None:
+    if st.session_state.current_instance not in available_instances:
         st.session_state.current_instance = available_instances[0]
 
     if st.session_state.current_page == "home":

--- a/butly_api/app.py
+++ b/butly_api/app.py
@@ -62,6 +62,24 @@ def _contract_component_schemas() -> Dict[str, Any]:
     return schemas
 
 
+def _public_contract_routes(app: FastAPI) -> list[Any]:
+    """FastAPI の include_router 構造を展開し、公開 v1 route だけを返す。"""
+    try:
+        from fastapi.routing import iter_route_contexts
+    except ImportError:
+        # FastAPI <= 0.136 は include_router 後の route が平坦化されている。
+        routes = app.routes
+    else:
+        # FastAPI >= 0.137 は include_router の階層を保持する。
+        routes = list(iter_route_contexts(app.routes))
+
+    return [
+        route
+        for route in routes
+        if is_api_v1_path(getattr(route, "path", "") or "")
+    ]
+
+
 def create_app(
     *,
     context: Optional[ApiContext] = None,
@@ -103,16 +121,11 @@ def create_app(
             return app.openapi_schema
         # legacy routers を同居させても、公開 contract（/openapi.json）は
         # /api/v1 だけにする。runtime の legacy route 挙動には影響しない。
-        v1_routes = [
-            route
-            for route in app.routes
-            if is_api_v1_path(getattr(route, "path", ""))
-        ]
         schema = get_openapi(
             title=app.title,
             version=app.version,
             description=app.description,
-            routes=v1_routes,
+            routes=_public_contract_routes(app),
         )
         components = schema.setdefault("components", {}).setdefault("schemas", {})
         for name, model_schema in _contract_component_schemas().items():

--- a/butly_api/routers/chat.py
+++ b/butly_api/routers/chat.py
@@ -14,7 +14,7 @@ SSE contract（schemas/chat.py の discriminated union が正本）:
   - 成功時は metadata 1回 → chunk 0回以上 → done 1回。
   - 失敗時は error 1回で終端し、done は送らない。
   - `sequence` は chunk ごとに単調増加。
-  - `done.full_text` は全 chunk 連結と一致する（ChatService が保証）。
+  - `done.full_text` は全 chunk 連結と一致する（router が保証）。
 """
 
 import logging
@@ -196,6 +196,7 @@ async def _typed_event_stream(
     ここで保証する。
     """
     sequence = 0
+    full_text_parts: List[str] = []
     try:
         async for event in runtime.chat_stream(internal_request):
             ev_type = event.get("type")
@@ -206,21 +207,37 @@ async def _typed_event_stream(
                     )
                 )
             elif ev_type == "chunk":
+                text = event.get("text", "")
+                if not isinstance(text, str):
+                    text = str(text)
+                full_text_parts.append(text)
                 yield format_sse_event(
                     ChatChunkEvent(
                         request_id=request_id,
                         sequence=sequence,
-                        data=ChatChunkData(text=event.get("text", "")),
+                        data=ChatChunkData(text=text),
                     )
                 )
                 sequence += 1
             elif ev_type == "done":
                 data = event.get("data") or {}
+                raw_full_text = data.get("full_text")
+                if not full_text_parts and isinstance(raw_full_text, str):
+                    full_text_parts.append(raw_full_text)
+                    if raw_full_text:
+                        yield format_sse_event(
+                            ChatChunkEvent(
+                                request_id=request_id,
+                                sequence=sequence,
+                                data=ChatChunkData(text=raw_full_text),
+                            )
+                        )
+                        sequence += 1
                 yield format_sse_event(
                     ChatDoneEvent(
                         request_id=request_id,
                         data=ChatDone(
-                            full_text=data.get("full_text", ""),
+                            full_text="".join(full_text_parts),
                             sources=_normalize_sources(data.get("sources")),
                         ),
                     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ openai
 numpy
 python-dotenv
 streamlit
-fastapi
+# 0.137.2 adds iter_route_contexts(), required by the versioned OpenAPI filter.
+fastapi>=0.137.2,<0.140
 uvicorn
 pyyaml
 pydantic-settings>=2.5,<3

--- a/tests/test_api_v1_chat.py
+++ b/tests/test_api_v1_chat.py
@@ -239,6 +239,27 @@ class TestStreamChat:
         # gatekeeper 内部 score は公開しない
         assert "scores" not in metadata
 
+    def test_done_full_text_is_router_chunk_concat(self, tmp_path):
+        runtime = FakeRuntime(
+            stream_events=[
+                {"type": "chunk", "text": "正"},
+                {"type": "chunk", "text": "解"},
+                {"type": "done", "data": {"full_text": "runtime mismatch"}},
+            ]
+        )
+        client = make_client(tmp_path, runtime)
+        resp = client.post(
+            "/api/v1/chat/stream", json={"instance_name": "t1", "text": "hi"}
+        )
+
+        events = parse_sse(resp.text)
+        chunks = [e for e in events if e["event"] == "chunk"]
+        joined = "".join(c["payload"]["data"]["text"] for c in chunks)
+        done = events[-1]["payload"]
+
+        assert joined == "正解"
+        assert done["data"]["full_text"] == joined
+
     def test_error_event_terminates_stream(self, tmp_path):
         runtime = FakeRuntime(
             stream_events=[


### PR DESCRIPTION
## Summary
- keep Streamlit settings reachable when the API is unavailable and normalize the configured API URL
- guarantee that SSE `done.full_text` matches the emitted chunk concatenation
- add a regression test for router-owned stream completion text

## Verification
- `./scripts/check_before_push.sh`
- 1123 passed, 7 deselected

This is the follow-up fix for frontend migration Phase 0.