### PR TITLE
feat: LoCoMo評価の進捗ログを追加

### DIFF
--- a/docs/reference/FILE_STRUCTURE.ja.md
+++ b/docs/reference/FILE_STRUCTURE.ja.md
@@ -115,6 +115,7 @@ LoCoMo公式JSONの固定会話をButlyへ投入する、環境非依存の評�
 | `checkpoint.py` | セッション/Sleeptime/QA単位のatomicなcheckpoint。run ID照合と破損検出つき |
 | `config.py` | CLI設定DTO（QA mode、sample/session/question範囲、localeを含み、`from_json_dict()`でresume時復元）とprofile YAML読込 |
 | `cli.py` | `run` / `resume` / `score` / `report` subcommands。`run`は`--qa-mode`、各`--*-limit` / `--all-*`、`--locale`を受け付け、採点・レポートまで実行 |
+| `progress.py` | CLI / Colab向けの即時進捗ログ。Replay・Sleeptime・QAの完了unitを0〜90%、採点・レポートを90〜100%としてstderrへ表示 |
 | `profiles/` | Full Local / Fixed Memory Pipelineのprofile例（`*.example.yaml`）。top-level `locale`は内部prompt／memory出力言語を指定 |
 | `colab/` | Drive・モデルサーバー・CLI呼び出しのみの薄いNotebook。ParametersセルでQA mode、locale、sample/session/questionの全件／上限制御を選択（評価ロジック禁止） |
 

--- a/docs/reference/FILE_STRUCTURE.md
+++ b/docs/reference/FILE_STRUCTURE.md
@@ -44,6 +44,8 @@ instances tree. The bundled mini fixture is synthetic.
 - `replay.py` — replay/Sleeptime/independent-or-sequential QA orchestration
   with checkpoint updates and `resume_evaluation()`; interrupted sequential
   questions roll back instance, result, and Trace state before retry.
+- `progress.py` — flushed CLI/Colab stderr progress; completed Replay,
+  Sleeptime, and QA units map to 0–90%, followed by scoring and reporting.
 - `artifacts.py` — JSON/JSONL, Trace copies, and before/after snapshots.
 - `scorer.py` — official-compatible scoring (normalized + stemmed token F1,
   per-category rules, no-information detection) plus Butly-specific metrics;

--- a/docs/reference/locomo_evaluation_flow.ja.md
+++ b/docs/reference/locomo_evaluation_flow.ja.md
@@ -269,6 +269,28 @@ RAG判断のドリフトなどを含む運用耐久評価に向く。
 
 独立QAの一時instanceはこのtree外のOS temp directoryに作られ、全質問後に削除される。
 
+## CLI / Colabの進捗表示
+
+`run`と`resume`は、長いモデル呼び出しの開始前と完了後に、次の形式で進捗を
+stderrへ即時出力する。Colabの実行セルは子プロセスのstderrをそのまま表示するため、
+Notebook側で出力を読み取る処理は不要。
+
+```text
+[LoCoMo  41.2%] [11/24] sleeptime | conv-26 session_6 completed
+```
+
+全体率は経過時間の予測ではなく、完了した処理件数による簡易指標。
+
+- Replay 1 session = 1 unit
+- Sleeptime 1 session = 1 unit
+- QA 1 question = 1 unit
+- 上記を0〜90%へ換算
+- 採点完了で96%、`summary.md`生成完了で100%
+
+各unitは同じ重みなので、モデルやsession長によって実時間とのずれは生じる。
+`resume`ではcheckpoint済みunitを初期完了数へ含めるため、表示は中断前の位置に近い
+割合から再開する。進捗はstderr、従来の最終結果JSONはstdoutの最終行に出力する。
+
 ## Checkpointの読み方
 
 `checkpoints/checkpoint.json`は、各サンプルについて次を記録する。

--- a/docs/reference/locomo_evaluation_flow.md
+++ b/docs/reference/locomo_evaluation_flow.md
@@ -261,6 +261,30 @@ behavior across long operational question sequences.
 Independent QA instances live outside this tree in the OS temporary directory
 and are deleted after all questions for the sample.
 
+## CLI and Colab live progress
+
+`run` and `resume` emit flushed progress before and after long model operations.
+The Colab run cell inherits the child process's stderr, so no notebook-side
+output reader is required.
+
+```text
+[LoCoMo  41.2%] [11/24] sleeptime | conv-26 session_6 completed
+```
+
+The overall percentage is a simple completed-work indicator rather than an
+elapsed-time estimate:
+
+- one replayed session is one unit;
+- one Sleeptime pass is one unit;
+- one answered question is one unit;
+- those units map to 0–90%;
+- scoring completes at 96%, and `summary.md` generation completes at 100%.
+
+Units have equal weight, so wall-clock progress varies with model and session
+length. A resumed run includes checkpointed units in its initial percentage and
+therefore continues near its prior position. Progress uses stderr, while the
+existing final result JSON remains the last stdout line.
+
 ## Reading the checkpoint
 
 For each sample, `checkpoints/checkpoint.json` records:

--- a/evals/locomo/README.md
+++ b/evals/locomo/README.md
@@ -85,6 +85,24 @@ QA. `--model-name` and `--connection` override the chat role for QA.
 the RAG cards, `rag_raw_max_chars` to cap them) to the evaluation instance
 config — see `profiles/*.example.yaml`.
 
+`run` and `resume` emit flushed live progress to stderr, so the Colab run cell
+shows the active sample, session, or question even during long model calls.
+Replay, Sleeptime, and QA each count as one equal work unit and occupy 0–90%;
+scoring occupies 90–96%, and report generation finishes at 100%. The percentage
+is therefore a simple completed-work indicator, not an elapsed-time estimate.
+The final result JSON remains the last stdout line.
+
+```text
+[LoCoMo   0.0%] [0/24] setup      | run=example; samples=1, sessions=11, questions=2, ...
+[LoCoMo  41.2%] [11/24] sleeptime | conv-26 session_6 completed
+[LoCoMo  86.2%] [23/24] qa         | conv-26 conv-26-qa-1 completed
+[LoCoMo  90.0%] score      | Official-compatible scoring starting
+[LoCoMo 100.0%] complete   | report completed; .../summary.md
+```
+
+On `resume`, already checkpointed Replay, Sleeptime, and QA units are included
+in the initial percentage instead of restarting the display from zero.
+
 The default QA mode is `independent`. Each question starts from the same
 post-Sleeptime memory state, so an earlier evaluation answer cannot affect a
 later question. Use `--qa-mode sequential` for an operational endurance run in

--- a/evals/locomo/cli.py
+++ b/evals/locomo/cli.py
@@ -9,6 +9,12 @@ from pathlib import Path
 from typing import Optional, Sequence
 
 from .config import ReplayConfig, SUPPORTED_EVALUATION_LOCALES
+from .progress import (
+    EVALUATION_PROGRESS_MAX,
+    SCORING_PROGRESS_MAX,
+    ProgressReporter,
+    create_console_progress,
+)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -105,8 +111,16 @@ def _command_run(args: argparse.Namespace) -> int:
     config = _replay_config_from_args(args)
     from .replay import run_evaluation
 
-    result = asyncio.run(run_evaluation(config))
-    return _finish(result, dataset=args.dataset, skip_scoring=args.skip_scoring)
+    progress_reporter = create_console_progress()
+    result = asyncio.run(
+        run_evaluation(config, progress_reporter=progress_reporter)
+    )
+    return _finish(
+        result,
+        dataset=args.dataset,
+        skip_scoring=args.skip_scoring,
+        progress_reporter=progress_reporter,
+    )
 
 
 def _replay_config_from_args(args: argparse.Namespace) -> ReplayConfig:
@@ -130,18 +144,36 @@ def _replay_config_from_args(args: argparse.Namespace) -> ReplayConfig:
 def _command_resume(args: argparse.Namespace) -> int:
     from .replay import resume_evaluation
 
-    result = asyncio.run(resume_evaluation(args.run_dir))
+    progress_reporter = create_console_progress()
+    result = asyncio.run(
+        resume_evaluation(
+            args.run_dir,
+            progress_reporter=progress_reporter,
+        )
+    )
     run_config = json.loads(
         result.workspace.run_config_path.read_text(encoding="utf-8")
     )
     dataset = Path(run_config["dataset_path"])
-    return _finish(result, dataset=dataset, skip_scoring=args.skip_scoring)
+    return _finish(
+        result,
+        dataset=dataset,
+        skip_scoring=args.skip_scoring,
+        progress_reporter=progress_reporter,
+    )
 
 
 def _command_score(args: argparse.Namespace) -> int:
     from .scorer import score_run
 
+    progress_reporter = create_console_progress()
+    progress_reporter.emit(0.0, "score", f"{args.run_dir} starting")
     scores = score_run(args.run_dir, dataset_path=args.dataset)
+    progress_reporter.emit(
+        100.0,
+        "score",
+        f"completed; overall={scores['official']['overall']:.4f}",
+    )
     print(
         json.dumps(
             {
@@ -159,12 +191,21 @@ def _command_score(args: argparse.Namespace) -> int:
 def _command_report(args: argparse.Namespace) -> int:
     from .report import write_report
 
+    progress_reporter = create_console_progress()
+    progress_reporter.emit(0.0, "report", f"{args.run_dir} starting")
     summary_path = write_report(args.run_dir)
+    progress_reporter.emit(100.0, "report", f"completed; {summary_path}")
     print(json.dumps({"summary_path": str(summary_path)}, ensure_ascii=False))
     return 0
 
 
-def _finish(result, *, dataset: Path, skip_scoring: bool) -> int:
+def _finish(
+    result,
+    *,
+    dataset: Path,
+    skip_scoring: bool,
+    progress_reporter: ProgressReporter,
+) -> int:
     payload = {
         "run_id": result.workspace.run_id,
         "run_dir": str(result.workspace.run_dir),
@@ -172,12 +213,38 @@ def _finish(result, *, dataset: Path, skip_scoring: bool) -> int:
         "replayed_sessions": result.replayed_sessions,
         "answered_questions": result.answered_questions,
     }
-    if not skip_scoring:
+    if skip_scoring:
+        progress_reporter.emit(
+            100.0,
+            "complete",
+            "Scoring and report skipped (--skip-scoring)",
+        )
+    else:
         from .report import write_report
         from .scorer import score_run
 
+        progress_reporter.emit(
+            EVALUATION_PROGRESS_MAX,
+            "score",
+            "Official-compatible scoring starting",
+        )
         scores = score_run(result.workspace.run_dir, dataset_path=dataset)
+        progress_reporter.emit(
+            SCORING_PROGRESS_MAX,
+            "score",
+            f"completed; overall={scores['official']['overall']:.4f}",
+        )
+        progress_reporter.emit(
+            SCORING_PROGRESS_MAX,
+            "report",
+            "summary.md generation starting",
+        )
         summary_path = write_report(result.workspace.run_dir)
+        progress_reporter.emit(
+            100.0,
+            "complete",
+            f"report completed; {summary_path}",
+        )
         payload["overall_score"] = scores["official"]["overall"]
         payload["scores_path"] = str(result.workspace.run_dir / "scores.json")
         payload["summary_path"] = str(summary_path)

--- a/evals/locomo/progress.py
+++ b/evals/locomo/progress.py
@@ -1,0 +1,70 @@
+"""Live console progress reporting for LoCoMo CLI commands."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Optional, TextIO
+
+
+EVALUATION_PROGRESS_MAX = 90.0
+SCORING_PROGRESS_MAX = 96.0
+
+
+class ProgressReporter:
+    """Emit flushed, human-readable progress without polluting JSON stdout."""
+
+    def __init__(self, logger: logging.Logger) -> None:
+        self._logger = logger
+
+    def emit(
+        self,
+        percent: float,
+        phase: str,
+        message: str,
+        *,
+        completed: Optional[int] = None,
+        total: Optional[int] = None,
+    ) -> None:
+        bounded_percent = min(max(percent, 0.0), 100.0)
+        step_text = ""
+        if completed is not None and total is not None:
+            step_text = f" [{completed}/{total}]"
+        self._logger.info(
+            "[LoCoMo %5.1f%%]%s %-10s | %s",
+            bounded_percent,
+            step_text,
+            phase,
+            message,
+        )
+
+    def emit_evaluation(
+        self,
+        completed: int,
+        total: int,
+        phase: str,
+        message: str,
+    ) -> None:
+        ratio = 1.0 if total == 0 else completed / total
+        self.emit(
+            ratio * EVALUATION_PROGRESS_MAX,
+            phase,
+            message,
+            completed=completed,
+            total=total,
+        )
+
+
+def create_console_progress(
+    stream: Optional[TextIO] = None,
+) -> ProgressReporter:
+    """Create an isolated stderr logger.
+
+    The stream handler flushes after every progress row.
+    """
+    logger = logging.Logger("evals.locomo.progress", level=logging.INFO)
+    handler = logging.StreamHandler(stream or sys.stderr)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    logger.addHandler(handler)
+    logger.propagate = False
+    return ProgressReporter(logger)

--- a/evals/locomo/replay.py
+++ b/evals/locomo/replay.py
@@ -29,6 +29,7 @@ from .config import (
     resolve_evaluation_locale,
 )
 from .dataset import LocomoConversation, load_dataset
+from .progress import ProgressReporter
 from .qa_runner import QARunner
 from .sleeptime_runner import SleeptimeRunner
 from .workspace import (
@@ -53,7 +54,11 @@ class EvaluationRunResult:
     answered_questions: int
 
 
-async def run_evaluation(config: ReplayConfig) -> EvaluationRunResult:
+async def run_evaluation(
+    config: ReplayConfig,
+    *,
+    progress_reporter: Optional[ProgressReporter] = None,
+) -> EvaluationRunResult:
     """Start a fresh run without importing any HTTP or UI layer."""
     config, profile = _resolve_config_and_profile(config)
     conversations = _select_conversations(load_dataset(config.dataset_path), config)
@@ -65,10 +70,21 @@ async def run_evaluation(config: ReplayConfig) -> EvaluationRunResult:
     workspace.assert_isolated()
     _write_run_metadata(workspace, config, conversations)
     checkpoint = Checkpoint.create(workspace.run_id, workspace.checkpoints_dir)
-    return await _execute(workspace, config, conversations, checkpoint, profile)
+    return await _execute(
+        workspace,
+        config,
+        conversations,
+        checkpoint,
+        profile,
+        progress_reporter,
+    )
 
 
-async def resume_evaluation(run_dir: Path) -> EvaluationRunResult:
+async def resume_evaluation(
+    run_dir: Path,
+    *,
+    progress_reporter: Optional[ProgressReporter] = None,
+) -> EvaluationRunResult:
     """Continue an interrupted run from its checkpoint without re-ingesting."""
     workspace = EvaluationWorkspace.open(run_dir)
     run_config = json.loads(
@@ -78,7 +94,14 @@ async def resume_evaluation(run_dir: Path) -> EvaluationRunResult:
     config, profile = _resolve_config_and_profile(config)
     conversations = _select_conversations(load_dataset(config.dataset_path), config)
     checkpoint = Checkpoint.load(workspace.run_id, workspace.checkpoints_dir)
-    return await _execute(workspace, config, conversations, checkpoint, profile)
+    return await _execute(
+        workspace,
+        config,
+        conversations,
+        checkpoint,
+        profile,
+        progress_reporter,
+    )
 
 
 async def _execute(
@@ -87,8 +110,34 @@ async def _execute(
     conversations: list[LocomoConversation],
     checkpoint: Checkpoint,
     profile: Optional[EvaluationProfile],
+    progress_reporter: Optional[ProgressReporter],
 ) -> EvaluationRunResult:
     instance_names_by_sample = _resolve_instance_names(conversations, checkpoint)
+    progress_total, progress_completed = _evaluation_progress_counts(
+        conversations,
+        config,
+        checkpoint,
+        instance_names_by_sample,
+    )
+    session_count = sum(
+        len(conversation.sessions[: config.session_limit])
+        for conversation in conversations
+    )
+    question_count = sum(
+        len(conversation.questions[: config.question_limit])
+        for conversation in conversations
+    )
+    _emit_progress(
+        progress_reporter,
+        progress_completed,
+        progress_total,
+        "setup",
+        (
+            f"run={workspace.run_id}; samples={len(conversations)}, "
+            f"sessions={session_count}, questions={question_count}, "
+            f"qa_mode={config.qa_mode}, locale={config.locale}"
+        ),
+    )
     runtime = workspace.create_runtime()
     sleeptime_runner = SleeptimeRunner(
         workspace.create_sleeptime(),
@@ -98,9 +147,19 @@ async def _execute(
     instance_names = []
     replayed_sessions = 0
     answered_questions = 0
-    for conversation in conversations:
+    for sample_index, conversation in enumerate(conversations, start=1):
         instance_name = instance_names_by_sample[conversation.sample_id]
         instance_names.append(instance_name)
+        _emit_progress(
+            progress_reporter,
+            progress_completed,
+            progress_total,
+            "sample",
+            (
+                f"{conversation.sample_id} "
+                f"({sample_index}/{len(conversations)}) starting"
+            ),
+        )
         progress = checkpoint.progress_for(conversation.sample_id, instance_name)
         sequential_recovery = SequentialQARecoveryPoint(
             workspace,
@@ -116,12 +175,22 @@ async def _execute(
         adapter = ReplayAdapter(components["memory"], conversation)
 
         sessions = conversation.sessions[: config.session_limit]
-        for session in sessions:
+        for session_index, session in enumerate(sessions, start=1):
             if session.session_id in progress.sleeptime_completed:
                 continue
             checkpoint.status = STATUS_REPLAYING
 
             if session.session_id not in progress.replayed_sessions:
+                _emit_progress(
+                    progress_reporter,
+                    progress_completed,
+                    progress_total,
+                    "replay",
+                    (
+                        f"{conversation.sample_id} {session.session_id} "
+                        f"({session_index}/{len(sessions)}) starting"
+                    ),
+                )
                 _discard_partial_session(
                     workspace.instances_dir / instance_name,
                     conversation.sample_id,
@@ -132,9 +201,27 @@ async def _execute(
                 )
                 progress.replayed_sessions.append(session.session_id)
                 checkpoint.save()
+                progress_completed += 1
+                _emit_progress(
+                    progress_reporter,
+                    progress_completed,
+                    progress_total,
+                    "replay",
+                    f"{conversation.sample_id} {session.session_id} completed",
+                )
 
             snapshot_root = (
                 workspace.snapshots_dir / instance_name / session.session_id
+            )
+            _emit_progress(
+                progress_reporter,
+                progress_completed,
+                progress_total,
+                "sleeptime",
+                (
+                    f"{conversation.sample_id} {session.session_id} "
+                    f"({session_index}/{len(sessions)}) starting"
+                ),
             )
             snapshot_instance(
                 workspace.instances_dir / instance_name,
@@ -152,6 +239,14 @@ async def _execute(
             progress.sleeptime_completed.append(session.session_id)
             checkpoint.save()
             replayed_sessions += 1
+            progress_completed += 1
+            _emit_progress(
+                progress_reporter,
+                progress_completed,
+                progress_total,
+                "sleeptime",
+                f"{conversation.sample_id} {session.session_id} completed",
+            )
 
         questions = conversation.questions[: config.question_limit]
         if len(questions) > progress.qa_completed:
@@ -169,10 +264,32 @@ async def _execute(
                 len(questions) > progress.qa_completed
             ):
                 canonical_dir = workspace.instances_dir / instance_name
+                _emit_progress(
+                    progress_reporter,
+                    progress_completed,
+                    progress_total,
+                    "qa-setup",
+                    (
+                        f"{conversation.sample_id} creating the "
+                        "post-Sleeptime baseline clone"
+                    ),
+                )
                 with IndependentQAWorkspace(canonical_dir) as qa_workspace:
                     for index, question in enumerate(questions):
                         if index < progress.qa_completed:
                             continue
+                        _emit_progress(
+                            progress_reporter,
+                            progress_completed,
+                            progress_total,
+                            "qa",
+                            (
+                                f"{conversation.sample_id} "
+                                f"{question.question_id} "
+                                f"({index + 1}/{len(questions)}) "
+                                "independent starting"
+                            ),
+                        )
                         qa_workspace.reset()
                         qa_runner = QARunner(
                             qa_workspace.create_runtime(),
@@ -190,6 +307,17 @@ async def _execute(
                         progress.qa_completed = index + 1
                         checkpoint.save()
                         answered_questions += 1
+                        progress_completed += 1
+                        _emit_progress(
+                            progress_reporter,
+                            progress_completed,
+                            progress_total,
+                            "qa",
+                            (
+                                f"{conversation.sample_id} "
+                                f"{question.question_id} completed"
+                            ),
+                        )
             elif config.qa_mode == "sequential":
                 qa_runner = QARunner(
                     runtime,
@@ -201,6 +329,18 @@ async def _execute(
                 for index, question in enumerate(questions):
                     if index < progress.qa_completed:
                         continue
+                    _emit_progress(
+                        progress_reporter,
+                        progress_completed,
+                        progress_total,
+                        "qa",
+                        (
+                            f"{conversation.sample_id} "
+                            f"{question.question_id} "
+                            f"({index + 1}/{len(questions)}) "
+                            "sequential starting"
+                        ),
+                    )
                     sequential_recovery.begin(
                         question_index=index,
                         question_id=question.question_id,
@@ -214,6 +354,17 @@ async def _execute(
                     checkpoint.save()
                     sequential_recovery.clear()
                     answered_questions += 1
+                    progress_completed += 1
+                    _emit_progress(
+                        progress_reporter,
+                        progress_completed,
+                        progress_total,
+                        "qa",
+                        (
+                            f"{conversation.sample_id} "
+                            f"{question.question_id} completed"
+                        ),
+                    )
         finally:
             if prev_now is None:
                 os.environ.pop(CHRONOS_NOW_ENV, None)
@@ -222,6 +373,13 @@ async def _execute(
 
     checkpoint.status = STATUS_COMPLETED
     checkpoint.save()
+    _emit_progress(
+        progress_reporter,
+        progress_total,
+        progress_total,
+        "evaluation",
+        "Replay, Sleeptime, and QA completed",
+    )
     return EvaluationRunResult(
         workspace=workspace,
         sample_ids=[conversation.sample_id for conversation in conversations],
@@ -229,6 +387,45 @@ async def _execute(
         replayed_sessions=replayed_sessions,
         answered_questions=answered_questions,
     )
+
+
+def _evaluation_progress_counts(
+    conversations: list[LocomoConversation],
+    config: ReplayConfig,
+    checkpoint: Checkpoint,
+    instance_names_by_sample: dict[str, str],
+) -> tuple[int, int]:
+    total = 0
+    completed = 0
+    for conversation in conversations:
+        sessions = conversation.sessions[: config.session_limit]
+        questions = conversation.questions[: config.question_limit]
+        total += len(sessions) * 2 + len(questions)
+        progress = checkpoint.progress_for(
+            conversation.sample_id,
+            instance_names_by_sample[conversation.sample_id],
+        )
+        completed += sum(
+            session.session_id in progress.replayed_sessions
+            for session in sessions
+        )
+        completed += sum(
+            session.session_id in progress.sleeptime_completed
+            for session in sessions
+        )
+        completed += min(max(progress.qa_completed, 0), len(questions))
+    return total, completed
+
+
+def _emit_progress(
+    reporter: Optional[ProgressReporter],
+    completed: int,
+    total: int,
+    phase: str,
+    message: str,
+) -> None:
+    if reporter is not None:
+        reporter.emit_evaluation(completed, total, phase, message)
 
 
 def _replay_session_logged(

--- a/tests/evals/test_locomo_progress.py
+++ b/tests/evals/test_locomo_progress.py
@@ -1,0 +1,27 @@
+"""Live progress output contract for LoCoMo CLI runs."""
+
+from io import StringIO
+
+from evals.locomo.progress import create_console_progress
+
+
+def test_evaluation_progress_maps_work_to_first_ninety_percent():
+    stream = StringIO()
+    reporter = create_console_progress(stream)
+
+    reporter.emit_evaluation(1, 4, "qa", "conv-1 qa-1 starting")
+
+    assert stream.getvalue() == (
+        "[LoCoMo  22.5%] [1/4] qa         | conv-1 qa-1 starting\n"
+    )
+
+
+def test_progress_is_clamped_and_flushed_to_the_given_stream():
+    stream = StringIO()
+    reporter = create_console_progress(stream)
+
+    reporter.emit(120.0, "complete", "done")
+
+    assert stream.getvalue() == (
+        "[LoCoMo 100.0%] complete   | done\n"
+    )

--- a/tests/evals/test_locomo_replay.py
+++ b/tests/evals/test_locomo_replay.py
@@ -1,6 +1,7 @@
 """External-API-free end-to-end tests for the replay runner and resume flow."""
 
 import asyncio
+from io import StringIO
 import json
 import os
 import sqlite3
@@ -15,6 +16,7 @@ from evals.locomo.cli import main as cli_main
 from evals.locomo.config import ReplayConfig
 from evals.locomo.dataset import LocomoConversation
 from evals.locomo.qa_runner import QARunner, build_qa_request
+from evals.locomo.progress import create_console_progress
 from evals.locomo.replay import (
     _discard_partial_session,
     _instance_name,
@@ -278,10 +280,19 @@ def test_resume_after_interruption_does_not_reingest(tmp_path):
         assert progress.replayed_sessions == ["session_1", "session_2"]
         assert progress.qa_completed == 0
 
-        result = asyncio.run(resume_evaluation(run_dir))
+        progress_stream = StringIO()
+        result = asyncio.run(
+            resume_evaluation(
+                run_dir,
+                progress_reporter=create_console_progress(progress_stream),
+            )
+        )
 
     assert result.replayed_sessions == 1
     assert result.answered_questions == 1
+    assert progress_stream.getvalue().splitlines()[0].startswith(
+        "[LoCoMo  54.0%] [3/5] setup"
+    )
 
     workspace = result.workspace
     replay_rows = _read_jsonl(workspace.results_dir / "replay_log.jsonl")
@@ -407,9 +418,18 @@ def test_cli_run_scores_reports_and_applies_profile(tmp_path, capsys):
         )
 
     assert exit_code == 0
-    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    captured = capsys.readouterr()
+    stdout_lines = captured.out.strip().splitlines()
+    payload = json.loads(stdout_lines[-1])
     assert payload["run_id"] == "cli-e2e"
     assert "overall_score" in payload
+    assert "setup" in captured.err
+    assert "replay" in captured.err
+    assert "sleeptime" in captured.err
+    assert "qa" in captured.err
+    assert "score" in captured.err
+    assert "report" in captured.err
+    assert "[LoCoMo 100.0%]" in captured.err
 
     run_dir = tmp_path / "runs" / "cli-e2e"
     scores = json.loads((run_dir / "scores.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## 変更内容
- LoCoMoの`run` / `resume`で、Replay・Sleeptime・QAの開始／完了をstderrへ即時表示
- 完了unitを0〜90%、採点を90〜96%、レポートを96〜100%として簡易進捗率を表示
- sample/session/questionの現在位置とQAモードを表示
- resume時はcheckpoint済みunitを初期進捗へ反映
- standaloneの`score` / `report`にも開始・完了ログを追加
- 日本語・英語の仕様書と評価READMEを更新

## 目的
Colabの評価セルが長時間無出力に見える問題を解消し、現在どのsample/session/questionを処理しているか確認できるようにします。進捗は処理件数ベースで、時間予測ではありません。

## 互換性
進捗はstderrへ出力し、従来の最終結果JSONはstdoutの最終行に維持します。Notebook側の処理変更は不要です。

## レビュー結果
- independent QAのbaseline/reset copy開始前にログが出ることを確認
- resume時の進捗再計算をcheckpointと照合
- stdout/stderrの分離と100%到達をE2Eで確認
- 追加モジュールへ通常flake8を実施

## 検証
- `venv/bin/python -m pytest tests/evals -q`: 91 passed
- `./scripts/check_before_push.sh`: 1388 passed, 7 deselected
- `pip check`: pass
- ローカルpnpm未導入のためfrontend checksはスキップ。Windows CIで確認します。